### PR TITLE
Use docker metadata to generate tags and labels

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,21 +33,15 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build Docker image tags
-        run: |
-          echo 'DOCKER_IMAGE_TAGS<<EOF' >> $GITHUB_ENV
-
-          # Add release tag if it matches pattern (e.g. 0.0.1)
-          if [[ ${{ github.ref_name }} =~ .+\..+\..+ ]]; then
-            echo ",ghcr.io/${{ github.repository }}:${{ github.ref_name }}" >> $GITHUB_ENV
-          fi
-
-          # Only add latest tag if master branch
-          if [[ ${{ github.ref_name }} == 'master' ]]; then
-            echo ",ghcr.io/${{ github.repository }}:latest" >> $GITHUB_ENV
-          fi
-
-          echo 'EOF' >> $GITHUB_ENV
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest
+            type=semver,pattern={{version}}
 
       # Only build and push Docker images for releases
       - name: Build and push Docker image to GitHub Container Registry
@@ -55,7 +49,8 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.DOCKER_IMAGE_TAGS }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             git_commit_id=${{ github.sha }}
           cache-from: type=local,src=/tmp/.buildx-cache


### PR DESCRIPTION
As the current docker image has no labels associated with it, especially not the opencontainer standard ones, tools like dependabot and renovate can't pull releasenotes or even link to commits.

```
regctl image config --format '{{ jsonPretty .Config.Labels }}' ghcr.io/axsuul/plex-media-server-exporter
null
```
vs
```
regctl image config --format '{{ jsonPretty .Config.Labels }}' ghcr.io/halkeye/plex-media-server-exporter:0.0.1
{
  "org.opencontainers.image.created": "2024-11-17T07:05:05.939Z",
  "org.opencontainers.image.description": "A better Prometheus exporter for Plex Media Server",
  "org.opencontainers.image.licenses": "MIT",
  "org.opencontainers.image.revision": "3ac5a255c6f8935bfd13eb31e883533dbbc02002",
  "org.opencontainers.image.source": "https://github.com/halkeye/plex-media-server-exporter",
  "org.opencontainers.image.title": "plex-media-server-exporter",
  "org.opencontainers.image.url": "https://github.com/halkeye/plex-media-server-exporter",
  "org.opencontainers.image.version": "0.0.1"
}
```
