### PR TITLE
Added PLEX_SSL_VERIFY env variable

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,6 +32,7 @@ PLATFORMS
   aarch64-linux
   arm64-darwin-21
   x64-mingw-ucrt
+  x86_64-linux
 
 DEPENDENCIES
   http (~> 5.1.1)

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ These environment variables can be passed into the container (defaults are in pa
   - How long to wait for Plex Media Server to respond
 * `PLEX_RETRIES_COUNT` (`0`)
   - How many times to retry failed Plex Media Server requests
+* `PLEX_SSL_VERIFY` (`true`)
+  - Whether to verify the SSL certificate when connecting with HTTPS
 * `METRICS_PREFIX` (`plex`)
   - What to prefix metric names with
 * `METRICS_MEDIA_COLLECTING_INTERVAL_SECONDS` (`300`)

--- a/lib/middleware/collector.rb
+++ b/lib/middleware/collector.rb
@@ -12,6 +12,7 @@ module PlexMediaServerExporter
         @plex_token = ENV["PLEX_TOKEN"]
         @plex_timeout = ENV["PLEX_TIMEOUT"]&.to_i || 10
         @plex_retries_count = ENV["PLEX_RETRIES_COUNT"]&.to_i || 0
+        @plex_ssl_verify = ENV['PLEX_SSL_VERIFY'] || "true"
 
         # Metrics configs
         @metrics_prefix = ENV["METRICS_PREFIX"] || "plex"
@@ -236,6 +237,7 @@ module PlexMediaServerExporter
 
           log(method: method, url: url)
 
+          options[:ssl] = {verify_mode: OpenSSL::SSL::VERIFY_NONE} if @plex_ssl_verify != "true"
           response = HTTP
             .timeout(@plex_timeout)
             .headers(


### PR DESCRIPTION
Added a `PLEX_SSL_VERIFY` environment variable to allow the exporter to connect to plex servers with self-signed certs. The default for this is set to `true` to ensure that the default behavior is the same.

Fixes issue #22 